### PR TITLE
口コミの編集・削除機能を実装#19

### DIFF
--- a/app/assets/stylesheets/common.css
+++ b/app/assets/stylesheets/common.css
@@ -689,3 +689,33 @@ ul {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.review-detail-card-button {
+  color: #ffffff;
+  padding: 10px 5px;
+  border-radius: .2rem;
+  box-shadow: 0 0 8px #B7B7B7;
+  margin: 0 6px;
+}
+
+.review-detail-card-button:active {
+  box-shadow: none;
+}
+
+.edit-color {
+  background-color: #7DB9B6;
+}
+
+.destroy-color {
+  background-color: #E96479;
+  padding-right: 10px;
+}
+
+.button-fonts {
+  margin: 0 5px;
+}
+
+.button-container {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,5 +1,6 @@
 class ReviewsController < ApplicationController
   before_action :search_params, only: %i[index search]
+  before_action :ensure_correct_user, only: %i[edit update destroy]
 
   def index
     @reviews = Review.all
@@ -73,5 +74,13 @@ class ReviewsController < ApplicationController
 
   def search_params
     @q = Review.ransack(params[:q])
+  end
+
+  def ensure_correct_user
+    @restaurant = Restaurant.find(params[:restaurant_id])
+    @review = Review.find(params[:id])
+    if @review.user_id != current_user.id
+      redirect_to restaurant_path(@restaurant)
+    end
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -47,6 +47,15 @@ class ReviewsController < ApplicationController
   end
 
   def destroy
+    @restaurant = Restaurant.find(params[:restaurant_id])
+    @review = Review.find(params[:id])
+    if @review.destroy
+      flash[:notice] = "口コミを削除しました"
+      redirect_to restaurant_path(@restaurant)
+    else
+      flash.now[:alert] = "口コミの削除に失敗しました"
+      render 'show'
+    end
   end
 
   def search

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -29,6 +29,26 @@ class ReviewsController < ApplicationController
     end
   end
 
+  def edit
+    @restaurant = Restaurant.find(params[:restaurant_id])
+    @review = Review.find(params[:id])
+  end
+
+  def update
+    @restaurant = Restaurant.find(params[:restaurant_id])
+    @review = Review.find(params[:id])
+    if @review.update(review_params)
+      flash[:notice] = '口コミを更新しました'
+      redirect_to restaurant_review_path(@restaurant, @review)
+    else
+      flash.now[:alert] = '口コミの更新に失敗しました'
+      render 'edit'
+    end
+  end
+
+  def destroy
+  end
+
   def search
     @reviews = Review.all
     @genres = Genre.all

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -7,9 +7,9 @@ class Review < ApplicationRecord
   has_one_attached :image
   belongs_to :user
   belongs_to :restaurant
-  has_many :review_feedback_options
+  has_many :review_feedback_options, dependent: :destroy
   has_many :feedback_options, through: :review_feedback_options
-  has_many :review_genres
+  has_many :review_genres, dependent: :destroy
   has_many :genres, through: :review_genres
   has_many :likes, dependent: :destroy
   has_many :users, through: :likes

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,66 @@
+<div class="wrap-container review-form-width">
+  <h2><%= "#{@restaurant.name}の口コミ編集画面" %></h2>
+  <%= render 'shared/flash' %>
+  <%= form_with model: @review, url: restaurant_review_path(@restaurant, @review), local: true do |f| %>
+    <div>
+      <p class="form-text-label">口コミを編集するお店の名前</p><br>
+      <%= @restaurant.name %>
+    </div>
+    <div>
+      <%= f.label :menu, "注文したメニュー", class: "form-text-label" %><br>
+      <%= f.text_field :menu, class: "form-text-input" %>
+      <%= render 'shared/error_messages', model: @review, attribute: :menu %>
+    </div>
+    <div>
+      <%= f.label :price, "料金", class: "form-text-label" %><br>
+      <span>¥</span>
+      <%= f.number_field :price, class: "form-number-input" %>
+      <%= render 'shared/error_messages', model: @review, attribute: :price %>
+    </div>
+    <div>
+      <%= f.label :image, "写真", class: "form-text-label" %><br>
+      <%= f.file_field :image, accept: "image/jpeg, image/gif, image/png", id: "image" %>
+    </div>
+    <div>
+      <%= f.label :visit_date, "ご利用日", class: "form-text-label" %><br>
+      <%= f.select :visit_date, [["平日", "平日"], ["土日", "土日"]] %>
+    </div>
+    <div>
+      <%= f.label :visit_time, "ご利用時間帯", class: "form-text-label" %><br>
+      <%= f.select :visit_time, [["ランチ", "ランチ"], ["ディナー", "ディナー"]] %>
+    </div>
+    <div>
+      <%= f.label :number_of_visitors, "ご利用人数", class: "form-text-label" %><br>
+      <%= f.number_field :number_of_visitors, class: "form-number-input" %>
+      <span>人</span>
+      <%= render 'shared/error_messages', model: @review, attribute: :number_of_visitors %>
+    </div>
+    <div>
+      <%= f.label :genres, "ジャンル", class: "form-text-label" %><br>
+      <div class="checkbox-container">
+        <%= collection_check_boxes(:review, :genre_ids, Genre.all, :id, :name) do |genre| %>
+          <%= genre.label { genre.check_box + genre.text } %>
+        <% end %>
+      </div>
+    </div>
+    <div>
+      <%= f.label :feedback_options, "お店の雰囲気・特徴・評価ポイントなど", class: "form-text-label" %><br>
+      <div class="checkbox-container">
+        <%= collection_check_boxes(:review, :feedback_option_ids, FeedbackOption.all, :id, :option_title) do |option| %>
+          <%= option.label { option.check_box + option.text } %>
+        <% end %>
+      </div>
+    </div>
+    <div>
+      <%= f.label :comment, "コメント", class: "form-text-label" %><br>
+      <%= f.text_area :comment, class: "form-comment-input" %>
+    </div>
+    <div>
+      <%= f.hidden_field :user_id, value: current_user.id %><br>
+      <%= f.hidden_field :restaurant_id, value: @restaurant.id %>
+    </div>
+    <div>
+      <%= f.submit "上記内容で口コミ内容を編集する", class: "submit-btn" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -54,8 +54,8 @@
       <div><%= @review.comment %></div>
       <div>
         <% if current_user.own?(@review) %>
-          編集・削除ボタン
           <%= link_to "編集", edit_restaurant_review_path(@restaurant, @review) %>
+          <%= link_to "削除", restaurant_review_path, method: :delete, data: {confirm: "#{@restaurant.name}の口コミを削除しますか？"} %>
         <% else %>
           <div id="like_buttons_<%= @review.id %>" class="like-button-container">
             <%= render 'shared/like_button', review: @review %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -54,8 +54,14 @@
       <div><%= @review.comment %></div>
       <div>
         <% if current_user.own?(@review) %>
-          <%= link_to "編集", edit_restaurant_review_path(@restaurant, @review) %>
-          <%= link_to "削除", restaurant_review_path, method: :delete, data: {confirm: "#{@restaurant.name}の口コミを削除しますか？"} %>
+          <div class="button-container">
+            <%= link_to edit_restaurant_review_path(@restaurant, @review), class: "review-detail-card-button edit-color" do %>
+              <span class="button-fonts">編集</span><i class="fa-solid fa-pen"></i>
+            <% end %>
+            <%= link_to restaurant_review_path, class: "review-detail-card-button destroy-color", method: :delete, data: {confirm: "#{@restaurant.name}の口コミを削除しますか？"} do %>
+              <span class="button-fonts">削除</span><i class="fa-solid fa-trash"></i>
+            <% end %>
+          </div>
         <% else %>
           <div id="like_buttons_<%= @review.id %>" class="like-button-container">
             <%= render 'shared/like_button', review: @review %>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -55,6 +55,7 @@
       <div>
         <% if current_user.own?(@review) %>
           編集・削除ボタン
+          <%= link_to "編集", edit_restaurant_review_path(@restaurant, @review) %>
         <% else %>
           <div id="like_buttons_<%= @review.id %>" class="like-button-container">
             <%= render 'shared/like_button', review: @review %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   }
   resource :profile, only: %i[show]
   resources :restaurants do
-    resources :reviews, only: %i[show new create] do  
+    resources :reviews, except: %i[index] do  
       resource :likes, only: %i[create destroy]
     end
   end


### PR DESCRIPTION
ルーティング設定
reviews コントローラーに edit / update / destroy アクションを追加
口コミ編集画面（editビュー）の作成
口コミ詳細画面で編集ボタンと削除ボタンを追加
自分が投稿した口コミであれば編集・削除ができるようにする (他のユーザーの口コミは編集・削除できない)