### PR TITLE
店舗詳細画面のN＋1クエリの解消#25

### DIFF
--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -22,6 +22,8 @@ class RestaurantsController < ApplicationController
   def show
     @restaurant = Restaurant.find(params[:id])
     @reviews = @restaurant.reviews
+                .includes(:genres, :feedback_options,
+                :likes, :user, {image_attachment: :blob})
   end
 
   private

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -48,7 +48,7 @@
                 <% if current_user.own?(review) %>
                   <div class="like-button-container">
                     <div><i class="fa-solid fa-heart"></i></div>
-                    <div class="review-likes-count"><%= review.likes.count %></div>
+                    <div class="review-likes-count"><%= review.likes.length %></div>
                   </div>
                 <% else %>
                   <div id="like_buttons_<%= review.id %>" class="like-button-container">


### PR DESCRIPTION
店舗詳細画面で、店舗の口コミに紐付く画像やタグ、いいね機能などを呼び出す際にN＋1クエリが発行されないように修正する