### PR TITLE
口コミを呼び出す際のN＋1クエリを解消する#27

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -3,5 +3,7 @@ class ProfilesController < ApplicationController
     @user = current_user
     @bookmark_restaurants = current_user.bookmark_restaurants
     @reviews = current_user.reviews
+                .includes(:genres, :feedback_options,
+                :likes, { image_attachment: :blob })
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -63,7 +63,10 @@ class ReviewsController < ApplicationController
     @reviews = Review.all
     @genres = Genre.all
     @feedback_options = FeedbackOption.all
-    @results = @q.result.distinct
+    @results = @q.result
+                .includes(:restaurant, :genres, :feedback_options,
+                :likes, { user: { avatar_attachment: :blob } },
+                { image_attachment: :blob }).distinct
   end
 
   private

--- a/app/views/shared/_like_button.html.erb
+++ b/app/views/shared/_like_button.html.erb
@@ -1,11 +1,11 @@
 <% if review.liked_by?(current_user) %>
   <%= link_to restaurant_review_likes_path(restaurant_id: review.restaurant_id, review_id: review.id, id: current_user.likes.find_by(review_id: review.id)), method: :delete, remote: true, data: { turbo: false } do %>
     <i class="fa-solid fa-heart"></i>
-    <div class="review-likes-count"><%= review.likes.count %></div>
+    <div class="review-likes-count"><%= review.likes.length %></div>
   <% end %>
 <% else %>
   <%= link_to restaurant_review_likes_path(restaurant_id: review.restaurant_id, review_id: review.id), method: :post, remote: true, data: { turbo: false } do %>
     <i class="fa-regular fa-heart"></i>
-    <div class="review-likes-count"><%= review.likes.count %></div>
+    <div class="review-likes-count"><%= review.likes.length %></div>
   <% end %>
 <% end %>

--- a/app/views/shared/_review_results.html.erb
+++ b/app/views/shared/_review_results.html.erb
@@ -41,7 +41,7 @@
             <% if current_user.own?(review) %>
               <div class="like-button-container">
                 <div><i class="fa-solid fa-heart"></i></div>
-                <div class="review-likes-count"><%= review.likes.count %></div>
+                <div class="review-likes-count"><%= review.likes.length %></div>
               </div>
             <% else %>
               <div id="like_buttons_<%= review.id %>" class="like-button-container">

--- a/app/views/shared/_reviews.html.erb
+++ b/app/views/shared/_reviews.html.erb
@@ -25,7 +25,7 @@
             </div>
             <div class="like-button-container">
               <div><i class="fa-solid fa-heart"></i></div>
-              <div class="review-likes-count"><%= review.likes.count %></div>
+              <div class="review-likes-count"><%= review.likes.length %></div>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
マイページで、口コミに紐付く画像やタグ、いいね機能などを呼び出す際にN＋1クエリが発行されないように修正する
口コミの検索結果画面で、口コミに紐付く画像やタグ、いいね機能などを呼び出す際にN＋1クエリが発行されないように修正する